### PR TITLE
Proposed fix for the CPANTESTER fail report.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,7 @@ WriteMakefile(
         'Path::Tiny'                     => 0,
         'Storable'                       => 0,
         'Data::Dumper'                   => 0,
-        'List::Util'                     => 0,
+        'List::Util'                     => '1.33',
         'Regexp::Common'                 => 0,
         'Regexp::Common::time'           => 0,
         'Regexp::Common::Email::Address' => 0,


### PR DESCRIPTION
Hi @jef-sure 

Please review the PR to fix the following CPANTESTER fail report by explicitly setting List::Util v1.33.

https://www.cpantesters.org/cpan/report/434374e0-bb24-11e8-98d5-bb14e5798fec

Here the Change from List::Util

         1.33 -- Sun Oct 13 01:35 UTC 2013
 
                   * Added any, all, none, notall list reduction functions
                     (inspired by List::MoreUtils)

Many Thanks.
Best Regards,
Mohammad S Anwar